### PR TITLE
Zmiana adresu w RSS feed

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -43,7 +43,7 @@ module.exports = {
           {
             site {
               siteMetadata {
-                site_url: url
+                site_url: siteUrl
                 title
                 description: subtitle
               }


### PR DESCRIPTION
RSS feed przekierowywał na adres akai.org.pl/posts/... zamiast na blog.akai.org.pl/posts/...